### PR TITLE
Issue #179: Fix for syncing files with size < defined multipart threshold

### DIFF
--- a/ait/commons/util/command/sync.py
+++ b/ait/commons/util/command/sync.py
@@ -60,12 +60,6 @@ class CmdSync:
                 try:
                     
                     fname = f.key[37:]
-                    contentType = ''
-                    obj_ = s3_cli.head_object(Bucket=self.aws.bucket_name, Key=f.key)
-                    if obj_ and obj_['ContentType']:
-                        contentType = obj_['ContentType']
-                        if "dcp-type=data" not in contentType:
-                            contentType += '; dcp-type=data'
 
                     copy_source = {
                         'Bucket': self.aws.bucket_name,
@@ -73,9 +67,13 @@ class CmdSync:
                     }
                     dest_key = dest_upload_area_uuid + '/' + fname
 
+                    content_type = "application/octet-stream; dcp-type=data"
                     s3_cli.copy(copy_source, dest_bucket, dest_key, 
                                     Callback=pbar.update, 
-                                    ExtraArgs={'ContentType': contentType},
+                                    ExtraArgs={
+                                        'ContentType': content_type,
+                                        'MetadataDirective': 'REPLACE',
+                                        },
                                     Config=get_transfer_config(f.size))
 
                     if not notify_upload(dest_env, dest_upload_area_uuid, fname):

--- a/ait/commons/util/command/sync.py
+++ b/ait/commons/util/command/sync.py
@@ -60,6 +60,12 @@ class CmdSync:
                 try:
                     
                     fname = f.key[37:]
+                    content_type = ''
+                    obj_ = s3_cli.head_object(Bucket=self.aws.bucket_name, Key=f.key)
+                    if obj_ and obj_['ContentType']:
+                        content_type = obj_['ContentType']
+                        if "dcp-type=data" not in content_type:
+                            content_type += '; dcp-type=data'
 
                     copy_source = {
                         'Bucket': self.aws.bucket_name,
@@ -67,8 +73,7 @@ class CmdSync:
                     }
                     dest_key = dest_upload_area_uuid + '/' + fname
 
-                    content_type = "application/octet-stream; dcp-type=data"
-                    s3_cli.copy(copy_source, dest_bucket, dest_key, 
+                    s3_cli.copy(copy_source, dest_bucket, dest_key,
                                     Callback=pbar.update, 
                                     ExtraArgs={
                                         'ContentType': content_type,


### PR DESCRIPTION
Fix for:
https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/179
and
https://github.com/ebi-ait/hca-ebi-wrangler-central/issues/139

The current implementation of `sync.py` defines the `MULTIPART_THRESHOLD` as `64 MB`

Comparing the file sizes of the invalid and valid files in this issue: https://github.com/ebi-ait/hca-ebi-wrangler-central/issues/139 showed that all invalid files had sizes less than 64 MB, (therefore were non multipart uploads) and all valid files had sizes greater than 64 MB (multipart uploads).

The invalid files were **not** being assigned the `contentType = dcp-type=data` which led them to not get validated by ingest.

As per the documentation here: https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html

`
 Note that if you are using any of the following parameters: --content-type, content-language, --content-encoding, --content-disposition, --cache-control, or --expires, you will need to specify --metadata-directive REPLACE for non-multipart copies if you want the copied objects to have the specified metadata values.
`

Adding `'MetadataDirective': 'REPLACE'` to the `copy` function fixes the issue. This is also in line with the `dcp-cli` implementation https://github.com/HumanCellAtlas/dcp-cli/blob/330caa679b0f7b1524235f2da41aed53060e8531/hca/upload/lib/s3_agent.py#L87


This was tested out by syncing files from the `hca-util upload area` created by @rays22  to the the `staging env upload area` here: https://staging.contribute.data.humancellatlas.org/submissions/detail?id=602bc0c2f29f510eee562e2e