### PR TITLE
Issue #185: fix for slow upload issue

### DIFF
--- a/ait/commons/util/command/upload.py
+++ b/ait/commons/util/command/upload.py
@@ -44,7 +44,7 @@ class CmdUpload:
         with ThreadPoolExecutor() as executor:
             # submit each job and map future to file
             futures = {}
-            for f in enumerate(files):
+            for f in files:
                 key = f"{prefix}{os.path.basename(f)}"
                 size = os.path.getsize(f)
 

--- a/ait/commons/util/command/upload.py
+++ b/ait/commons/util/command/upload.py
@@ -60,10 +60,10 @@ class CmdUpload:
             success = True
             for future in concurrent.futures.as_completed(futures):
                 try:
-                    f = futures[future]
+                    file_path = futures[future]
                     future.result()  # read the result of the future object
                 except Exception as ex:
-                    print(f"Exception raised for {f}: ", ex)
+                    print(f"Exception raised for {file_path}: ", ex)
                     success = False
 
             return success

--- a/ait/commons/util/command/upload.py
+++ b/ait/commons/util/command/upload.py
@@ -77,10 +77,6 @@ class CmdUpload:
 
         try:
 
-            # filter out any duplicate path after expansion
-            # . -> curent drectory
-            # ~ -> user home directory
-
             ps = []
             for p in self.args.PATH:
                 p = os.path.abspath(p)  # Normalize a pathname by collapsing redundant separators and up-level references so that A//B, A/B/, A/./B and A/foo/../B all become A/B.

--- a/ait/commons/util/command/upload.py
+++ b/ait/commons/util/command/upload.py
@@ -3,7 +3,6 @@ import filetype
 
 from ait.commons.util.settings import DIR_SUPPORT, MAX_DIR_DEPTH
 from ait.commons.util.common import format_err
-from ait.commons.util.file_transfer import FileTransfer, TransferProgress
 from ait.commons.util.local_state import get_selected_area
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor

--- a/ait/commons/util/command/upload.py
+++ b/ait/commons/util/command/upload.py
@@ -6,8 +6,7 @@ from ait.commons.util.common import format_err
 from ait.commons.util.local_state import get_selected_area
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
-import threading
-from tqdm import tqdm
+from ait.commons.util.progress_bar import ProgressBar
 
 
 class CmdUpload:
@@ -125,17 +124,4 @@ class CmdUpload:
         except Exception as e:
             return False, format_err(e, 'upload')
 
-
-class ProgressBar:
-    def __init__(self, target, total):
-        self._target = target
-        self._total = total
-        self._seen_so_far = 0
-        self._lock = threading.Lock()
-
-    def __call__(self, bytes_amount):
-        with tqdm(total=self._total, desc=self._target) as pbar:
-            with self._lock:
-                self._seen_so_far += bytes_amount
-            pbar.update(self._seen_so_far)
 

--- a/ait/commons/util/command/upload.py
+++ b/ait/commons/util/command/upload.py
@@ -46,7 +46,6 @@ class CmdUpload:
                                                         Callback=ProgressBar(target=file_path, total=file_size),
                                                         ExtraArgs={'ContentType': content_type}
                                                         )
-            return True
 
     def upload_files(self, files, prefix):
 

--- a/ait/commons/util/command/upload.py
+++ b/ait/commons/util/command/upload.py
@@ -3,7 +3,7 @@ import filetype
 
 from ait.commons.util.settings import DIR_SUPPORT, MAX_DIR_DEPTH
 from ait.commons.util.common import format_err
-from ait.commons.util.file_transfer import FileTransfer, TransferProgress, transfer
+from ait.commons.util.file_transfer import FileTransfer, TransferProgress
 from ait.commons.util.local_state import get_selected_area
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
@@ -92,7 +92,6 @@ class CmdUpload:
             def upload_file(file_transfer, prefix):
 
                 key = f"{prefix}{file_transfer.key}"
-                print(key)
                 if not self.args.o and self.aws.obj_exists(key):
                     file_transfer.status = 'File exists. Use -o to overwrite.'
                     file_transfer.successful = True

--- a/ait/commons/util/file_transfer.py
+++ b/ait/commons/util/file_transfer.py
@@ -1,6 +1,7 @@
 # from multiprocessing.dummy import Pool
 import threading
 from time import sleep
+from tqdm import tqdm
 
 
 class TransferProgress(object):
@@ -10,16 +11,10 @@ class TransferProgress(object):
         self._lock = threading.Lock()
 
     def __call__(self, bytes_amount):
-
-        with self._lock:
-            self._file_transfer.seen_so_far += bytes_amount
-            percentage = (self._file_transfer.seen_so_far / self._file_transfer.size) * 100
-
-            if percentage == 100.0:
-                self._file_transfer.complete = True
-                self._file_transfer.successful = True
-
-            self._file_transfer.status = f'({percentage:.2f}%)'
+        with tqdm(total=self._file_transfer.size, desc=self._file_transfer.key) as pbar:
+            with self._lock:
+                self._file_transfer.seen_so_far += bytes_amount
+            pbar.update(self._file_transfer.seen_so_far)
 
 
 class FileTransfer:

--- a/ait/commons/util/file_transfer.py
+++ b/ait/commons/util/file_transfer.py
@@ -1,7 +1,6 @@
 # from multiprocessing.dummy import Pool
 import threading
 from time import sleep
-from tqdm import tqdm
 
 
 class TransferProgress(object):
@@ -11,10 +10,16 @@ class TransferProgress(object):
         self._lock = threading.Lock()
 
     def __call__(self, bytes_amount):
-        with tqdm(total=self._file_transfer.size, desc=self._file_transfer.key) as pbar:
-            with self._lock:
-                self._file_transfer.seen_so_far += bytes_amount
-            pbar.update(self._file_transfer.seen_so_far)
+
+        with self._lock:
+            self._file_transfer.seen_so_far += bytes_amount
+            percentage = (self._file_transfer.seen_so_far / self._file_transfer.size) * 100
+
+            if percentage == 100.0:
+                self._file_transfer.complete = True
+                self._file_transfer.successful = True
+
+            self._file_transfer.status = f'({percentage:.2f}%)'
 
 
 class FileTransfer:

--- a/ait/commons/util/progress_bar.py
+++ b/ait/commons/util/progress_bar.py
@@ -1,0 +1,16 @@
+import threading
+import tqdm
+
+
+class ProgressBar:
+    def __init__(self, target, total):
+        self._target = target
+        self._total = total
+        self._seen_so_far = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, bytes_amount):
+        with tqdm(total=self._total, desc=self._target) as pbar:
+            with self._lock:
+                self._seen_so_far += bytes_amount
+            pbar.update(self._seen_so_far)

--- a/ait/commons/util/progress_bar.py
+++ b/ait/commons/util/progress_bar.py
@@ -1,5 +1,5 @@
 import threading
-import tqdm
+from tqdm import tqdm
 
 
 class ProgressBar:


### PR DESCRIPTION
Fixes [#185](https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/185)

- added `ThreadPoolExecutor` to the upload file
- used `tqdm` for tracking upload progress
- removed the dependency of classes in `file_transfer.py`, from `upload.py`. Created a new class `ProgressBar` in `upload.py` to track upload. This class should eventually be used throughout the code base
- refactored code, converted inner functions into class functions for better readability / maintainability.

The value for `max workers / threads` is currently the set as the default in `ThreadPoolExecutor`, which is `os.cpu_count() * 5`. This can be tweaked around and experimented with for performance improvements.

output of a sample run:

```
python -m ait.commons.util upload data/2_5KB
Uploading...
/Users/yhaider/hca/hca-util/data/2_5KB/test0_2_5KB.fastq.gz: 100%|██████████████████| 5120/5120 [00:00<00:00, 95021400.35it/s]
/Users/yhaider/hca/hca-util/data/2_5KB/test1_2_5KB.fastq.gz: 100%|██████████████████| 5120/5120 [00:00<00:00, 92964660.09it/s]
Successful upload
```